### PR TITLE
Fix issue where calendar would not display 12/31/2017

### DIFF
--- a/Colander.podspec
+++ b/Colander.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Colander'
-  s.version          = '0.2'
+  s.version          = '0.2.1'
   s.summary          = 'A highly customizable iOS calendar view'
 
   s.description      = <<-DESC

--- a/Colander/Classes/CalendarViewModel.swift
+++ b/Colander/Classes/CalendarViewModel.swift
@@ -118,7 +118,7 @@ class CalendarViewModel {
             lastDisplayIndex -= (dayDifference - 1)
         }
 
-        let requiredRows = ceil(Double(lastDisplayIndex) / Double(daysPerWeek))
+        let requiredRows = ceil(Double(lastDisplayIndex + 1) / Double(daysPerWeek))
         let requiredItems = Int(requiredRows) * daysPerWeek
 
         // We display full rows for every week we display, even if the current month starts or ends before the week.

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Colander (0.2):
+  - Colander (0.2.1):
     - SnapKit (~> 4.0)
     - SwiftDate (~> 4.5.0)
   - Nimble (7.0.3)
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Colander: 17ca6579685233417f79de740a72fda7760b5dbd
+  Colander: 5b0f56adaa5baa86b2cb58f87946fef90069d28a
   Nimble: 7f5a9c447a33002645a071bddafbfb24ea70e0ac
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   Reveal-SDK: 58517b2a4d5d69dcb98e62aa4a5e62c84b5e0061

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Colander (0.1.1):
+  - Colander (0.2):
     - SnapKit (~> 4.0)
     - SwiftDate (~> 4.5.0)
   - Nimble (7.0.3)
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Colander: ba6e0729d146c1fd77341f7d34c78e14e12fe640
+  Colander: 17ca6579685233417f79de740a72fda7760b5dbd
   Nimble: 7f5a9c447a33002645a071bddafbfb24ea70e0ac
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   Reveal-SDK: 58517b2a4d5d69dcb98e62aa4a5e62c84b5e0061

--- a/Example/Tests/CalendarViewModelSpec.swift
+++ b/Example/Tests/CalendarViewModelSpec.swift
@@ -108,6 +108,33 @@ class CalendarViewModelSpec: QuickSpec {
                     expect(subject.date(at: IndexPath(item: 32, section: 0))).to(beNil())
                 }
             }
+
+            context("in a month whose final day is the first day of a week") {
+                beforeEach {
+                    let startDate = Date.mockDateFrom(year: 2017, month: 12, day: 1)
+                    let endDate = Date.mockDateFrom(year: 2017, month: 12, day: 1)
+                    subject = try! CalendarViewModel(startDate: startDate, endDate: endDate,
+                                                     showLeadingWeeks: true, showTrailingWeeks: true)
+                }
+
+                it("has the right date count") {
+                    expect(subject.dates(in: 0).count).to(equal(42))
+                }
+
+                it("returns nil for index paths that fall in the leading or trailing days") {
+                    expect(subject.date(at: IndexPath(item: 0, section: 0))).to(beNil())
+                    expect(subject.date(at: IndexPath(item: 36, section: 0))).to(beNil())
+                }
+
+                it("returns days corresponding to index paths") {
+                    expect(subject.date(at: IndexPath(item: 5, section: 0)))
+                        .to(equal(Date.mockDateFrom(year: 2017, month: 12, day: 1)))
+                    expect(subject.date(at: IndexPath(item: 30, section: 0)))
+                        .to(equal(Date.mockDateFrom(year: 2017, month: 12, day: 26)))
+                    expect(subject.date(at: IndexPath(item: 35, section: 0)))
+                        .to(equal(Date.mockDateFrom(year: 2017, month: 12, day: 31)))
+                }
+            }
         }
 
         describe("indexPath(from:)") {


### PR DESCRIPTION
This branch fixes an issue where the calendar view would not display December 31st 2017.  This was due to a small off-by-one error in the calculation of the required number of rows in a month.  Added tests against this bug as well.