### PR TITLE
Fix item selection for months which don't start on Sunday.

### DIFF
--- a/Colander.podspec
+++ b/Colander.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Colander'
-  s.version          = '0.2.4'
+  s.version          = '0.2.5'
   s.summary          = 'A highly customizable iOS calendar view'
 
   s.description      = <<-DESC
@@ -17,10 +17,9 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '10.0'
   s.swift_version = '5.0'
 
-
   s.source_files = 'Colander/Classes/**/*'
 
-  s.dependency 'SnapKit', '~> 5.0.0'
-  s.dependency 'SwiftDate', '~> 6.0.3'
+  s.dependency 'SnapKit', '~> 5.0.1'
+  s.dependency 'SwiftDate', '~> 6.3.1'
 
 end

--- a/Colander/Classes/CalendarView.swift
+++ b/Colander/Classes/CalendarView.swift
@@ -2,7 +2,7 @@ import SnapKit
 import SwiftDate
 import UIKit
 
-public protocol CalendarViewDataSource: class {
+public protocol CalendarViewDataSource: AnyObject {
     var calendar: Calendar { get }
     var startDate: Date { get }
     var endDate: Date { get }
@@ -24,7 +24,7 @@ public extension CalendarViewDataSource {
     }
 }
 
-public protocol CalendarViewDelegate: class {
+public protocol CalendarViewDelegate: AnyObject {
     func scrollViewDidScroll(_ scrollView: UIScrollView)
     func calendar(_ calendar: CalendarView, shouldSelectCellAt date: Date) -> Bool
     func calendar(_ calendar: CalendarView, didSelectCell cell: UICollectionViewCell, forDate date: Date)
@@ -302,7 +302,7 @@ extension CalendarView: UICollectionViewDataSource {
         }
 
         if let currentMonthInfo = viewModel?.monthInfos[indexPath.section], var headerView = headerView as? Dated {
-            headerView.date = currentMonthInfo.startDate
+            headerView.date = currentMonthInfo.startDate.date
         }
 
         return headerView

--- a/Colander/Classes/DateExtensions.swift
+++ b/Colander/Classes/DateExtensions.swift
@@ -3,32 +3,3 @@ import SwiftDate
 internal extension Calendar {
     static let gregorian = Calendar(identifier: Calendar.Identifier.gregorian)
 }
-
-internal extension Date {
-    var beginningOfMonth: Date {
-        var calendar = Calendar(identifier: Calendar.Identifier.gregorian)
-        if let timeZone = TimeZone(secondsFromGMT: 0) {
-            calendar.timeZone = timeZone
-        }
-        var firstDayOfStartMonth = calendar.dateComponents( [.era, .year, .month], from: self)
-        firstDayOfStartMonth.day = 1
-        return calendar.date(from: firstDayOfStartMonth) ?? Date.nowAt(.startOfMonth)
-    }
-    
-    var beginningOfWeek: Date {
-        var calendar = Calendar(identifier: Calendar.Identifier.gregorian)
-        if let timeZone = TimeZone(secondsFromGMT: 0) {
-            calendar.timeZone = timeZone
-        }
-        return calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: self)) ?? Date.nowAt(.startOfWeek)
-    }
-
-    var endOfWeek: Date {
-        let numWeekdays = Calendar.gregorian.weekdaySymbols.count
-        return self + (numWeekdays - self.weekday).days
-    }
-
-    func isSameMonthAs(_ otherDate: Date) -> Bool {
-        return year == otherDate.year && month == otherDate.month
-    }
-}

--- a/Colander/Classes/MonthInfo.swift
+++ b/Colander/Classes/MonthInfo.swift
@@ -10,23 +10,16 @@ import Foundation
 import SwiftDate
 
 struct MonthInfo {
-    let startDate: Date
-    let endDate: Date
+    let startDate: DateInRegion
+    let endDate: DateInRegion
     let firstDayWeekdayIndex: Int
     let numberOfDaysInMonth: Int
 
-    init(forMonthContaining date: Date, with calendar: Calendar? = nil) throws {
-        var targetCalendar = calendar ?? Calendar(identifier: Calendar.Identifier.gregorian)
-        targetCalendar.timeZone = calendar?.timeZone ?? TimeZone(secondsFromGMT: 0)!
-        
-        guard let numberOfDaysInMonth = targetCalendar.range(of: .day, in: .month, for: date)?.count else {
-            throw DateError.Generic("Could not determine number of days in month for \(date)")
-        }
-
-        let beginningOfMonth = date.beginningOfMonth
-        self.startDate = beginningOfMonth
-        self.endDate = beginningOfMonth + numberOfDaysInMonth.days
-        self.firstDayWeekdayIndex = targetCalendar.component(.weekday, from: startDate) - 1 // 1-indexed to 0-indexed
-        self.numberOfDaysInMonth = numberOfDaysInMonth
+    init(forMonthContaining date: Date, with calendar: Calendar) throws {
+        let workingDate = DateInRegion(date, region: Region(calendar: calendar, zone: calendar.timeZone, locale: calendar.locale ?? Locale.current))
+        self.startDate = workingDate.dateAtStartOf(.month)
+        self.endDate = workingDate.dateAtEndOf(.month)
+        self.firstDayWeekdayIndex = calendar.component(.weekday, from: startDate.date) - 1 // 1-indexed to 0-indexed
+        self.numberOfDaysInMonth = date.monthDays
     }
 }

--- a/Example/Colander.xcodeproj/project.pbxproj
+++ b/Example/Colander.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1089385E523011FABC5B870B /* Colander.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Colander.podspec; path = ../Colander.podspec; sourceTree = "<group>"; };
+		1089385E523011FABC5B870B /* Colander.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Colander.podspec; path = ../Colander.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		1939F3CCD64571E5E090650F /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		3E2AE24330433B58DE569374 /* Pods_Colander_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Colander_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD01AFB9204008FA782 /* Colander_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Colander_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -340,7 +340,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Colander_Example/Pods-Colander_Example-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Colander_Example/Pods-Colander_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Colander/Colander.framework",
 				"${BUILT_PRODUCTS_DIR}/SnapKit/SnapKit.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftDate/SwiftDate.framework",
@@ -353,7 +353,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Colander_Example/Pods-Colander_Example-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Colander_Example/Pods-Colander_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B3060291EC9B55999E1EBEBE /* [CP] Check Pods Manifest.lock */ = {
@@ -380,7 +380,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Colander_Tests/Pods-Colander_Tests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Colander_Tests/Pods-Colander_Tests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
 			);
@@ -391,7 +391,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Colander_Tests/Pods-Colander_Tests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Colander_Tests/Pods-Colander_Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/Colander.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Colander.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -7,20 +7,7 @@ target 'Colander_Example' do
   target 'Colander_Tests' do
     inherit! :search_paths
 
-    pod 'Quick', '~> 2.1.0'
-    pod 'Nimble', '~> 8.0.1'
+    pod 'Quick', '~> 4.0.0'
+    pod 'Nimble', '~> 9.2.0'
   end
-end
-
-post_install do |installer|
-    installer.pods_project.targets.each do |target|
-        if target.name == "Nimble"
-            target.build_configurations.each do |config|
-                xcconfig_path = config.base_configuration_reference.real_path
-                xcconfig = File.read(xcconfig_path)
-                new_xcconfig = xcconfig.sub('lswiftXCTest', 'lXCTestSwiftSupport')
-                File.open(xcconfig_path, "w") { |file| file << new_xcconfig }
-            end
-        end
-    end
 end

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -11,3 +11,16 @@ target 'Colander_Example' do
     pod 'Nimble', '~> 8.0.1'
   end
 end
+
+post_install do |installer|
+    installer.pods_project.targets.each do |target|
+        if target.name == "Nimble"
+            target.build_configurations.each do |config|
+                xcconfig_path = config.base_configuration_reference.real_path
+                xcconfig = File.read(xcconfig_path)
+                new_xcconfig = xcconfig.sub('lswiftXCTest', 'lXCTestSwiftSupport')
+                File.open(xcconfig_path, "w") { |file| file << new_xcconfig }
+            end
+        end
+    end
+end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Colander (0.2.3):
+  - Colander (0.2.4):
     - SnapKit (~> 5.0.0)
     - SwiftDate (~> 6.0.3)
   - Nimble (8.0.1)
@@ -13,7 +13,7 @@ DEPENDENCIES:
   - Quick (~> 2.1.0)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - Nimble
     - Quick
     - SnapKit
@@ -24,12 +24,12 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Colander: fcc5af3359a55ff63098c9d31a81156955a83c20
+  Colander: 1fdc1a3915ff17d77fb3aa3eb80614187b5892c9
   Nimble: 45f786ae66faa9a709624227fae502db55a8bdd0
   Quick: 4be43f6634acfa727dd106bdf3929ce125ffa79d
   SnapKit: fd22d10eb9aff484d79a8724eab922c1ddf89bcf
   SwiftDate: 8d4f14bf1ef68e95094511504856547bf9e3e1a6
 
-PODFILE CHECKSUM: 8986d9112fcd8cc93adf8e946860b85e291ba26f
+PODFILE CHECKSUM: 0978970aeaacea6c5a4013a8e8b4c44da5690fab
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.10.0

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
   - Colander (0.2.4):
-    - SnapKit (~> 5.0.0)
-    - SwiftDate (~> 6.0.3)
-  - Nimble (8.0.1)
-  - Quick (2.1.0)
-  - SnapKit (5.0.0)
-  - SwiftDate (6.0.3)
+    - SnapKit (~> 5.0.1)
+    - SwiftDate (~> 6.3.1)
+  - Nimble (9.2.0)
+  - Quick (4.0.0)
+  - SnapKit (5.0.1)
+  - SwiftDate (6.3.1)
 
 DEPENDENCIES:
   - Colander (from `../`)
-  - Nimble (~> 8.0.1)
-  - Quick (~> 2.1.0)
+  - Nimble (~> 9.2.0)
+  - Quick (~> 4.0.0)
 
 SPEC REPOS:
   trunk:
@@ -24,12 +24,12 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Colander: 1fdc1a3915ff17d77fb3aa3eb80614187b5892c9
-  Nimble: 45f786ae66faa9a709624227fae502db55a8bdd0
-  Quick: 4be43f6634acfa727dd106bdf3929ce125ffa79d
-  SnapKit: fd22d10eb9aff484d79a8724eab922c1ddf89bcf
-  SwiftDate: 8d4f14bf1ef68e95094511504856547bf9e3e1a6
+  Colander: 59d264cbc922fba799f9753af144339ccea1593e
+  Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
+  Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
+  SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
+  SwiftDate: 72d28954e8e1c6c1c0f917ccc8005e4f83c7d4b2
 
-PODFILE CHECKSUM: 0978970aeaacea6c5a4013a8e8b4c44da5690fab
+PODFILE CHECKSUM: 0e0a04c7fc638aff5349877b0a815224f5cc4510
 
 COCOAPODS: 1.10.0

--- a/Example/Tests/CalendarViewModelSpec.swift
+++ b/Example/Tests/CalendarViewModelSpec.swift
@@ -19,7 +19,7 @@ class CalendarViewModelSpec: QuickSpec {
                 let endDate = startDate + 1.weeks
                 let subject = try! CalendarViewModel(startDate: startDate, endDate: endDate)
                 expect(subject.monthInfos.count).to(equal(1))
-                let mockMonthInfo = try! MonthInfo(forMonthContaining: startDate)
+                let mockMonthInfo = try! MonthInfo(forMonthContaining: startDate, with: .gregorian)
                 let monthInfo = subject.monthInfos.first!
                 expect(monthInfo.startDate).to(equal(mockMonthInfo.startDate))
                 expect(monthInfo.numberOfDaysInMonth).to(equal(mockMonthInfo.numberOfDaysInMonth))
@@ -33,7 +33,7 @@ class CalendarViewModelSpec: QuickSpec {
                 let subject = try CalendarViewModel(startDate: startDate, endDate: endDate)
                 expect(subject.monthInfos.count).to(equal(expectedCount))
                 for (i, monthInfo) in subject.monthInfos.enumerated() {
-                    let mockMonthInfo = try! MonthInfo(forMonthContaining: startDate + i.months)
+                    let mockMonthInfo = try! MonthInfo(forMonthContaining: startDate + i.months, with: .gregorian)
                     expect(monthInfo.startDate).to(equal(mockMonthInfo.startDate))
                     expect(monthInfo.numberOfDaysInMonth).to(equal(mockMonthInfo.numberOfDaysInMonth))
                 }

--- a/Example/Tests/Date+Mock.swift
+++ b/Example/Tests/Date+Mock.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftDate
+@testable import Colander
 
 extension Date {
     /// Creates a `Date` instance with given components
@@ -9,14 +10,7 @@ extension Date {
     ///   - month: the desired month
     ///   - day: the desired day
     /// - Returns: a new instance of `Date` with the given components
-    static func mockDateFrom(year: Int, month: Int, day: Int, hour: Int = 0) -> Date {
-        var components = DateComponents(year: year, month: month, day: day, hour: hour)
-        // nsdate is timezone independent, essentially representing GMT,
-        // so make sure the calendar is parsing the date in GMT as well
-        if let timeZone = TimeZone(secondsFromGMT: 0) {
-            components.timeZone = timeZone
-        }
-        let dateInRegion : DateInRegion = DateInRegion(components: components, region: nil)!
-        return dateInRegion.date
+    static func mockDateFrom(year: Int, month: Int, day: Int, hour: Int = 0, calendar: Calendar = .gregorian) -> Date {
+        return calendar.date(from: DateComponents(year: year, month: month, day: day, hour: hour))!
     }
 }

--- a/Example/Tests/MonthInfoSpec.swift
+++ b/Example/Tests/MonthInfoSpec.swift
@@ -16,7 +16,7 @@ class MonthInfoSpec: QuickSpec {
         describe("init") {
             it("Correctly decides firstDayWeekdayIndex and number of days for a 31-day month") {
                 // Today
-                let monthInfo = try! MonthInfo(forMonthContaining: Date.mockDateFrom(year: 2017, month: 8, day: 4))
+                let monthInfo = try! MonthInfo(forMonthContaining: Date.mockDateFrom(year: 2017, month: 8, day: 4), with: .gregorian)
 
                 // August 1, 2017 is a Tuesday
                 expect(monthInfo.firstDayWeekdayIndex).to(equal(2))
@@ -27,7 +27,7 @@ class MonthInfoSpec: QuickSpec {
 
             it("Correctly decides firstDayWeekdayIndex and number of days for a 30-day month") {
                 // June 25, 2017
-                let monthInfo = try! MonthInfo(forMonthContaining: Date.mockDateFrom(year: 2017, month: 6, day: 25))
+                let monthInfo = try! MonthInfo(forMonthContaining: Date.mockDateFrom(year: 2017, month: 6, day: 25), with: .gregorian)
 
                 // Juen 1, 2017 is a Thursday
                 expect(monthInfo.firstDayWeekdayIndex).to(equal(4))
@@ -38,7 +38,7 @@ class MonthInfoSpec: QuickSpec {
 
             it("Correctly decides firstDayWeekdayIndex and number of days for a normal February") {
                 // February 10, 2017
-                let monthInfo = try! MonthInfo(forMonthContaining: Date.mockDateFrom(year: 2017, month: 2, day: 10))
+                let monthInfo = try! MonthInfo(forMonthContaining: Date.mockDateFrom(year: 2017, month: 2, day: 10), with: .gregorian)
 
                 // February 1, 2017 is a Tuesday
                 expect(monthInfo.firstDayWeekdayIndex).to(equal(3))
@@ -49,7 +49,7 @@ class MonthInfoSpec: QuickSpec {
 
             it("Correctly decides firstDayWeekdayIndex and number of days for a leap year February") {
                 // February 14, 2016
-                let monthInfo = try! MonthInfo(forMonthContaining: Date.mockDateFrom(year: 2016, month: 2, day: 14))
+                let monthInfo = try! MonthInfo(forMonthContaining: Date.mockDateFrom(year: 2016, month: 2, day: 14), with: .gregorian)
 
                 // February 1, 2016 is a Monday
                 expect(monthInfo.firstDayWeekdayIndex).to(equal(1))
@@ -60,10 +60,10 @@ class MonthInfoSpec: QuickSpec {
             
             it("Correctly decides beginningOfMonth for startDate") {
                 // September 10, 2019
-                let monthInfo = try! MonthInfo(forMonthContaining: Date.mockDateFrom(year: 2019, month: 9, day: 10))
+                let monthInfo = try! MonthInfo(forMonthContaining: Date.mockDateFrom(year: 2019, month: 9, day: 10), with: .gregorian)
 
                 // September 1, 2019 is a Sunday
-                expect(monthInfo.startDate.beginningOfMonth.day).to(equal(1))
+                expect(monthInfo.startDate.dateAtStartOf(.month).day).to(equal(1))
             }
         }
     }


### PR DESCRIPTION
Due to gremlins in the calculation of number of days between the first Sunday presented in a section and the selected date later in the month for those months which did not start on a Sunday, the selection would be off by one and cause a bunch of nastiness where several dates would be selected even if multiple selection was disallowed.

Another bug resulted from mismatched timezones. Some dates were being treated as GMT, while others were the current devices time zone. Now dates within the framework should all be aligned with the calendar passed as an argument to the view model, and it's up to the consumer of the framework to make sure that meshes properly with the `Dated` items being presented.

Finally there was some jank in interactive example that I cleanup up so that it would be useful.